### PR TITLE
[Fix]: 메인 페이지와 찜하기 페이지에서의 찜하기 기능 수정 완료

### DIFF
--- a/src/lib/components/likes/Activity.svelte
+++ b/src/lib/components/likes/Activity.svelte
@@ -1,27 +1,17 @@
 <script lang="ts">
+	import type { Activities } from '$lib/types/likes';
 	import { supabase } from '$lib/supabase';
 	import { slide, fade } from 'svelte/transition';
 	import { user, toast } from '$lib/stores';
 	import Icon from '$lib/Icon.svelte';
-	export let imgUrl = '';
-	export let title = '';
+
 	export let id = '';
-	export let short_details = '';
-	export let recruiting = true;
-	export let startDate = '';
-	export let endDate = '';
-	export let status = '';
-	export let likes = {};
+	export let activities: Activities;
+
 	import moment from 'moment';
 	moment.locale('ko');
 
-	// 찜하기 위한 함수 정의
-	const postLike = async (user_id: string, activity_id: string) => {
-		const { error } = await supabase.from('likes').insert({ user_id, activity_id });
-		if (!error) return true;
-		else false;
-	};
-
+	// 찜하기 제거 위한 함수
 	const postDisLike = async (user_id: string, activity_id: string) => {
 		const { data, error } = await supabase.from('likes').delete().match({ user_id, activity_id });
 		if (!error) return true;
@@ -30,9 +20,9 @@
 
 	let liked = true;
 	const likeBtn = async () => {
-		liked = !liked;
-		const result = liked ? await postLike($user?.id, id) : await postDisLike($user?.id, id);
-		$toast = result ? (liked ? '찜하기 완료' : '찜한항목 제거') : '찜하기 실패';
+		const result = await postDisLike($user?.id, activities.id);
+		if (result) liked = false;
+		$toast = result ? '찜한항목 제거' : '찜하기 실패';
 	};
 
 	// 진행상태 메시지 가공 위한 객체
@@ -45,14 +35,16 @@
 
 	// 모집중 메시지
 	const recruitingMSG = () => {
-		return recruiting
+		return activities.recruiting
 			? `<div class="mt-1 text-blue-600">지원 가능</div>`
 			: `<div class="mt-1 text-red-600">지원 불가</div>`;
 	};
 
 	// 진행상태 메시지
 	const statusMSG = () => {
-		return `<div class="mt-3 ${statusVariation[status].color}">${statusVariation[status].content}</div>`;
+		return `<div class="mt-3 ${statusVariation[activities.status].color}">${
+			statusVariation[activities.status].content
+		}</div>`;
 	};
 
 	// 간단한 설명 보여주기
@@ -61,7 +53,7 @@
 
 {#if liked}
 	<a
-		href="/activities/{id}"
+		href="/activities/{activities.id}"
 		class="w-full relative 2xl:h-[524px] lg:h-[434px] h-[524px] mb-12 shadow-2xl rounded-lg overflow-hidden {liked
 			? ''
 			: 'hidden'}"
@@ -73,7 +65,11 @@
 				in:fade|local={{ duration: 400 }}
 				out:slide|local={{ duration: 600 }}
 			>
-				<img src={imgUrl} alt={title} class="w-full hover:scale-125 duration-200" />
+				<img
+					src={activities.images.url}
+					alt={activities.title}
+					class="w-full hover:scale-125 duration-200"
+				/>
 			</div>
 		{/if}
 		<div
@@ -87,17 +83,17 @@
 		>
 			<div class="flex justify-between items-center">
 				<p class="w-full mt-2 text-lg {hovering ? '' : 'truncate'}">
-					{title}
+					{activities.title}
 				</p>
 			</div>
 
 			{@html statusMSG()}
 			{@html recruitingMSG()}
-			<div class="mt-3">시작일 {moment(startDate).format('YYYY.MM.DD')}</div>
-			<div class="mt-1">종료일 {moment(endDate).format('YYYY.MM.DD')}</div>
+			<div class="mt-3">시작일 {moment(activities.start_at).format('YYYY.MM.DD')}</div>
+			<div class="mt-1">종료일 {moment(activities.end_at).format('YYYY.MM.DD')}</div>
 			{#if hovering}
 				<p class="w-full h-max pt-8 text-xs text-ellipsis" in:fade={{ duration: 800 }}>
-					{short_details}
+					{activities.short_details}
 				</p>
 			{/if}
 		</div>

--- a/src/lib/components/likes/ActivityWrapper.svelte
+++ b/src/lib/components/likes/ActivityWrapper.svelte
@@ -1,29 +1,17 @@
 <script lang="ts">
 	import Activity from '$lib/components/likes/Activity.svelte';
-	import type { Activities } from '$lib/types/main';
+	import type { Likes } from '$lib/types/likes';
 	import { fade } from 'svelte/transition';
-	import moment from 'moment';
 
-	export let activities_type_kor = '전체활동';
-	export let Activites: ArrayLike<Activities>;
+	export let Likes: ArrayLike<Likes>;
 </script>
 
 <div in:fade={{ duration: 500 }}>
-	<div class=" lg:mt-8 mb-4 lg:text-3xl text-xl">{activities_type_kor}</div>
-	{#if Activites?.length}
+	<div class=" lg:mt-8 mb-4 lg:text-3xl text-xl">찜한 활동</div>
+	{#if Likes?.length}
 		<div class="mb-8 grid lg:grid-cols-3 2xl:gap-10 lg:gap-3">
-			{#each Activites as { title, recruiting, start_at, end_at, id, status, images, short_details, likes }}
-				<Activity
-					imgUrl={images.url}
-					{id}
-					{title}
-					{recruiting}
-					{status}
-					{short_details}
-					{likes}
-					startDate={moment(start_at).format('YYYY-MM-DD')}
-					endDate={moment(end_at).format('YYYY-MM-DD')}
-				/>
+			{#each Likes as { id, activities }}
+				<Activity {id} {activities} />
 			{/each}
 		</div>
 	{:else}

--- a/src/lib/components/main/Activity.svelte
+++ b/src/lib/components/main/Activity.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+	import type { Likes } from '$lib/types/main';
 	import { supabase } from '$lib/supabase';
 	import { slide, fade } from 'svelte/transition';
 	import { user, toast } from '$lib/stores';
+	import { getContext } from 'svelte';
 	import Icon from '$lib/Icon.svelte';
 	export let imgUrl = '';
 	export let title = '';
@@ -11,7 +13,6 @@
 	export let startDate = '';
 	export let endDate = '';
 	export let status = '';
-	export let likes = {};
 	import moment from 'moment';
 	moment.locale('ko');
 
@@ -28,7 +29,9 @@
 		else return false;
 	};
 
-	let liked = Object.keys(likes).length !== 0;
+	let liked = $user
+		? getContext('likes').filter((el: Likes) => el?.activity_id === id)?.length
+		: false;
 	const likeBtn = async () => {
 		liked = !liked;
 		const result = liked ? await postLike($user?.id, id) : await postDisLike($user?.id, id);

--- a/src/lib/components/main/ActivityWrapper.svelte
+++ b/src/lib/components/main/ActivityWrapper.svelte
@@ -12,7 +12,7 @@
 	<div class=" lg:mt-8 mb-4 lg:text-3xl text-xl">{activities_type_kor}</div>
 	{#if Activites?.length}
 		<div class="mb-8 grid lg:grid-cols-3 2xl:gap-10 lg:gap-3">
-			{#each Activites as { title, recruiting, start_at, end_at, id, status, images, short_details, likes }}
+			{#each Activites as { title, recruiting, start_at, end_at, id, status, images, short_details }}
 				<Activity
 					imgUrl={images.url}
 					{id}
@@ -20,7 +20,6 @@
 					{recruiting}
 					{status}
 					{short_details}
-					{likes}
 					startDate={moment(start_at).format('YYYY-MM-DD')}
 					endDate={moment(end_at).format('YYYY-MM-DD')}
 				/>

--- a/src/lib/types/likes/index.ts
+++ b/src/lib/types/likes/index.ts
@@ -1,0 +1,22 @@
+export type Activities = {
+	title: string;
+	recruiting: string;
+	start_at: string;
+	end_at: string;
+	id: string;
+	status: string;
+	short_details: string;
+	details: string;
+	activities_type: {
+		type: string;
+		type_kor: string;
+	};
+	images: {
+		url: string;
+	};
+};
+
+export interface Likes {
+	id: string;
+	activities: Activities;
+}

--- a/src/lib/types/main/index.ts
+++ b/src/lib/types/main/index.ts
@@ -15,7 +15,8 @@ export interface Activities {
 	start_at: Date;
 	end_at: Date;
 	title: string;
-	likes: {
-		id: string;
-	}[];
+}
+
+export interface Likes {
+	activity_id: string;
 }

--- a/src/routes/likes/+page.svelte
+++ b/src/routes/likes/+page.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-	import type { Activities } from '$lib/types/main';
+	import type { Likes } from '$lib/types/likes';
 	import ActivityWrapper from '$lib/components/likes/ActivityWrapper.svelte';
 
 	/** @type {import('./$types').PageData} */
 	export let data: any;
 
-	const Likes: ArrayLike<Activities> = data.activities;
+	const Likes: ArrayLike<Likes> = data.likes;
 </script>
 
 <!-- Activity 컴포넌트 주입 -->
 <div class="w-full lg:p-12 p-3">
 	<!-- all -->
-	<ActivityWrapper Activites={Likes} activities_type_kor={'찜한 활동'} />
+	<ActivityWrapper {Likes} />
 </div>

--- a/src/routes/likes/+page.ts
+++ b/src/routes/likes/+page.ts
@@ -2,15 +2,19 @@ import { supabase } from '$lib/supabase';
 import { user } from '$lib/stores';
 import { get } from 'svelte/store';
 
-/** @type {import('./$types').PageLoad} */
-export async function load({ parent }) {
-	await parent();
+const getLikes = async () => {
 	const { data, error } = await supabase
 		.from('likes')
 		.select(
-			'activities(title, recruiting, start_at, end_at, id, status, short_details, details, activities_type("type", "type_kor"), images("url"), likes("id"))'
+			'id, activities(title, recruiting, start_at, end_at, id, status, short_details, details, activities_type("type", "type_kor"), images("url"))'
 		)
-		.match({ user_id: get(user)?.id })
-		.order('created_at', { ascending: false });
-	return { activities: error ? null : data?.map((el) => el.activities) };
+		.match({ user_id: get(user)?.id });
+	return error ? [] : data;
+};
+
+/** @type {import('./$types').PageLoad} */
+export async function load({ parent }) {
+	await parent();
+	const likes = get(user) ? await getLikes() : [];
+	return { likes };
 }

--- a/src/routes/main/+page.svelte
+++ b/src/routes/main/+page.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
-	import type { Activities } from '$lib/types/main';
+	import type { Activities, Likes } from '$lib/types/main';
 	import { activitiesToShow } from '$lib/stores';
 	import ActivityWrapper from '$lib/components/main/ActivityWrapper.svelte';
+	import { setContext } from 'svelte';
 
 	/** @type {import('./$types').PageData} */
 	export let data: any;
-	console.log(data);
 
+	// 찜하기 관련 정보 : context로 전달
+	const likes: ArrayLike<Likes> = data.likes;
+	setContext('likes', likes);
+
+	// 활동 관련 정보 : props로 전달 후 ActivityWrapper에서 뿌려주기
 	const All: ArrayLike<Activities> = data.activities;
 
 	const Studies: ArrayLike<Activities> = data.activities.filter(

--- a/src/routes/main/+page.ts
+++ b/src/routes/main/+page.ts
@@ -1,12 +1,29 @@
 import { supabase } from '$lib/supabase';
+import { user } from '$lib/stores';
+import { get } from 'svelte/store';
 
-/** @type {import('./$types').PageLoad} */
-export async function load() {
-	const { data } = await supabase
+const getActivities = async () => {
+	const { data, error } = await supabase
 		.from('activities')
 		.select(
-			'title, recruiting, start_at, end_at, id, status, short_details, details, activities_type("type", "type_kor"), images("url"), likes("id")'
+			'title, recruiting, start_at, end_at, id, status, short_details, details, activities_type("type", "type_kor"), images("url")'
 		)
 		.order('created_at', { ascending: false });
-	return { activities: data };
+	return error ? [] : data;
+};
+
+const getLikes = async () => {
+	const { data, error } = await supabase
+		.from('likes')
+		.select('id, activity_id')
+		.match({ user_id: get(user)?.id });
+	return error ? [] : data;
+};
+
+/** @type {import('./$types').PageLoad} */
+export async function load({ parent }) {
+	await parent();
+	const activities = await getActivities();
+	const likes = get(user) ? await getLikes() : [];
+	return { activities, likes };
 }


### PR DESCRIPTION
[진행한 사항]
- 메인 페이지와 찜하기 페이지에 존재하는 찜하기 기능 오류 수정 완료
- 이전에는 해당 활동 찜한 사용자 데이터를 가져와서 현재 사용자와 비교했는데 -> 현재 사용자가 찜한 활동 다 가져와서 특정 활동 찜했는지 안했는지 비교 하는 것으로 수정 (다른 사용자 데이터 노출 방지)
  - 이후에 테이블 별로 정책 설정까지 해서 2중으로 보안 제공할 예정